### PR TITLE
<set> was omitted when not using Boost

### DIFF
--- a/AutoDiff/GradientStructure.hpp
+++ b/AutoDiff/GradientStructure.hpp
@@ -28,7 +28,7 @@
 #include <boost/container/flat_set.hpp>
 #include <boost/container/flat_map.hpp>
 #else
-//#include <set>
+#include <set>
 #include "../Utilities/flat_map.hpp"
 #include "../Utilities/flat_set.hpp"
 #endif


### PR DESCRIPTION
Now it works (on Linux), using "make" then "make run" in Tests directory
